### PR TITLE
Export the RuleValidators type as part of the API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export { SyncValidator as Validator, AsyncValidator } from './CoreValidator';
+export { SyncValidator as Validator, AsyncValidator,  } from './CoreValidator';
 export { ValidationErrors } from 'ValidationErrors';
+export { RuleValidators } from 'valueValidator/RuleValidators'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { SyncValidator as Validator, AsyncValidator,  } from './CoreValidator';
+export { SyncValidator as Validator, AsyncValidator } from './CoreValidator';
 export { ValidationErrors } from 'ValidationErrors';
-export { RuleValidators } from 'valueValidator/RuleValidators'
+export { RuleValidators, AsyncRuleValidators } from 'valueValidator/RuleValidators'


### PR DESCRIPTION
Hi there!

Thanks for writing such an awesome library - I really appreciate it.

I've used it to great effect in an angular project, extending the angular `FormGroup` so that you can actually have strongly-typed validation rules (instead of the OOB experience which only allows abstract rules).

I was going to turn this into a little angular library, but I've hit a snag. My implementation creates a custom rule validator, which basically unpacks the value from the angular form field and passes it to `ruleForTransformed()`. This works fine using the inferred type for that method when the implementation is within my consuming application. However, the compiler blows up when I try to export the type declarations for that inferred type.

There's a pretty easy fix for this - it all works fine if I import `RuleValidators` and explicitly type my custom rule validator.

Would you be happy to approve this change to the API, to allow me (and others) to extend rule validators?